### PR TITLE
Fix task/dependency bugs in plan creation, release, and lead conversion

### DIFF
--- a/sfdx-source/LabsActionPlans/main/default/classes/ActionPlanCreateInvocable.cls
+++ b/sfdx-source/LabsActionPlans/main/default/classes/ActionPlanCreateInvocable.cls
@@ -190,7 +190,16 @@ global inherited sharing class ActionPlanCreateInvocable {
 
 					apTask.Action_Plan__c = ap.Id;
 
-					apTask.Status__c = ActionPlansUtilities.getTaskRecordTypeStatusDefaultValues().get(ActionPlansUtilities.getDefaultTaskRecordTypeId());
+					// Use the template's Task record type (carried on the Action Plan) to
+					// pick the default status, not the running user's default record type.
+					// The builder path (ActionPlansBuilderUtilities) already does this, so
+					// a template whose record type's default status differs from the user's
+					// default no longer inserts with the wrong (or an invalid) status.
+					if (!String.isBlank(ap.TaskRecordTypeID__c) && ap.TaskRecordTypeID__c instanceof Id && ap.TaskRecordTypeID__c.startsWithIgnoreCase('012')) {
+						apTask.Status__c = ActionPlansUtilities.getTaskRecordTypeStatusDefaultValues().get(ap.TaskRecordTypeID__c);
+					} else {
+						apTask.Status__c = ActionPlansUtilities.getTaskRecordTypeStatusDefaultValues().get(ActionPlansUtilities.getDefaultTaskRecordTypeId());
+					}
 
 					if (apTask.Dependent__c != null && apTask.Dependent__c != 'None') {
 						apTask.ActivityDate__c = null;
@@ -243,6 +252,13 @@ global inherited sharing class ActionPlanCreateInvocable {
 		}
 
 		for (APTask__c apTask : planTaskIndexToTask.values()) {
+			// Dependent tasks must NOT get a Salesforce Task yet. One is created by
+			// ActionPlansTaskTriggerUtilities when the controlling task is closed.
+			// Creating it now releases the successor immediately instead of waiting
+			// for its predecessor. The builder path already defers these.
+			if (apTask.Dependent__c != null && apTask.Dependent__c != 'None') {
+				continue;
+			}
 			ActionPlan__c insertedAP;
 			// check if task exists already
 			Task t = new Task();
@@ -300,7 +316,7 @@ global inherited sharing class ActionPlanCreateInvocable {
 			dmlEmail.EmailHeader.TriggerUserEmail = true;
 
 			Database.DMLOptions dmlNoEmail = new Database.DMLOptions();
-			dmlEmail.EmailHeader.TriggerUserEmail = false;
+			dmlNoEmail.EmailHeader.TriggerUserEmail = false;
 
 			if (apTask.SendEmail__c == true) {
 				t.setOptions(dmlEmail);

--- a/sfdx-source/LabsActionPlans/main/default/classes/ActionPlansBuilderUtilities.cls
+++ b/sfdx-source/LabsActionPlans/main/default/classes/ActionPlansBuilderUtilities.cls
@@ -117,7 +117,7 @@ public inherited sharing class ActionPlansBuilderUtilities {
 		dmlEmail.EmailHeader.TriggerUserEmail = true;
 
 		Database.DMLOptions dmlNoEmail = new Database.DMLOptions();
-		dmlEmail.EmailHeader.TriggerUserEmail = false;
+		dmlNoEmail.EmailHeader.TriggerUserEmail = false;
 
 		Map<Id, Id> objectOwnersMap = retrieveOwnersDataRelatedObject(this.relatedRecordIDs);
 		//insert Action Plans to DB
@@ -163,6 +163,17 @@ public inherited sharing class ActionPlansBuilderUtilities {
 		String defaultTaskStatus = ActionPlansUtilities.getTaskRecordTypeStatusDefaultValues().get(ActionPlansUtilities.getDefaultTaskRecordTypeId());
 
 		for (ActionPlan__c ap : relActionPlans) {
+			// Collect this plan's tasks in template order so a dependent task's
+			// Dependent__c index resolves to the controlling task WITHIN THE SAME
+			// plan. aptList is flat across every plan, so indexing it directly
+			// makes the second and later plans point at the first plan's tasks.
+			List<APTask__c> thisPlanTasks = new List<APTask__c>();
+			for (APTask__c at : aptList) {
+				if (at.Action_Plan__c == null || at.Action_Plan__c == ap.Id) {
+					thisPlanTasks.add(at);
+				}
+			}
+
 			for (APTask__c at : aptList) {
 				if (at.Action_Plan__c != null && at.Action_Plan__c != ap.Id) {
 					continue;
@@ -182,7 +193,7 @@ public inherited sharing class ActionPlansBuilderUtilities {
 
 				if (at.Dependent__c != null && at.Dependent__c != 'None') {
 					Integer tempIndex = Integer.valueOf(at.Dependent__c);
-					at.Controller__c = aptList[tempIndex].Id;
+					at.Controller__c = thisPlanTasks[tempIndex].Id;
 					at.ActivityDate__c = null;
 				} else {
 					at.Controller__c = null;

--- a/sfdx-source/LabsActionPlans/main/default/classes/ActionPlansTaskTriggerUtilities.cls
+++ b/sfdx-source/LabsActionPlans/main/default/classes/ActionPlansTaskTriggerUtilities.cls
@@ -203,7 +203,14 @@ public without sharing class ActionPlansTaskTriggerUtilities {
 				d = controllingTasks.get(dependentApt.Controller__c).ActivityDate__c;
 			}
 
-			dependentApt.ActivityDate__c = d.addDays(dependentApt.DaysFromStart__c.intValue());
+			// Honor the plan's skip-weekend setting when scheduling the released
+			// task, matching how the due date was first computed in
+			// upsertDependentAPTasks (a raw addDays would land on a weekend).
+			if (dependentApt.Action_Plan__r.SkipWeekends__c == true && dependentApt.Action_Plan__r.SkipDay__c != null) {
+				dependentApt.ActivityDate__c = ActionPlansUtilities.adjustTaskDueDate(d, dependentApt.DaysFromStart__c.intValue(), dependentApt.Action_Plan__r.SkipDay__c);
+			} else {
+				dependentApt.ActivityDate__c = d.addDays(dependentApt.DaysFromStart__c.intValue());
+			}
 
 			if (dependentApt.Comments__c != null) {
 				t2.Description = dependentApt.Comments__c;
@@ -242,7 +249,17 @@ public without sharing class ActionPlansTaskTriggerUtilities {
 
 			t2.Type = dependentApt.Type__c;
 
-			String defaultStatus = ActionPlansUtilities.getTaskRecordTypeStatusDefaultValues().get(ActionPlansUtilities.getDefaultTaskRecordTypeId());
+			// Use the dependent task's Task record type (set on t2 above) for the
+			// default status, not the running user's default record type, so a
+			// template on a non-default record type doesn't start with (or fail
+			// validation on) a status that isn't valid for that record type.
+			String defaultStatus;
+			if (ActionPlansUtilities.taskUsesRecordTypes && dependentApt.Task_RecordTypeId__c != null) {
+				defaultStatus = ActionPlansUtilities.getTaskRecordTypeStatusDefaultValues().get(dependentApt.Task_RecordTypeId__c);
+			}
+			if (defaultStatus == null) {
+				defaultStatus = ActionPlansUtilities.getTaskRecordTypeStatusDefaultValues().get(ActionPlansUtilities.getDefaultTaskRecordTypeId());
+			}
 			t2.Status = defaultStatus;
 
 			t2.ActivityDate = dependentApt.ActivityDate__c;

--- a/sfdx-source/LabsActionPlans/main/default/classes/ActionPlansTriggerHandlers.cls
+++ b/sfdx-source/LabsActionPlans/main/default/classes/ActionPlansTriggerHandlers.cls
@@ -665,19 +665,41 @@ global inherited sharing class ActionPlansTriggerHandlers {
 				for (Lead l : newRecords) {
 					if (l.IsConverted && !oldRecordsMap.get(l.Id).IsConverted && apMap.containsKey(l.Id)) {
 						for (ActionPlan__c ap : apMap.get(l.Id)) {
+							Id destinationId;
 							switch on destinationObject {
 								when 'account' {
-									ap.Account__c = l.ConvertedAccountId;
+									destinationId = l.ConvertedAccountId;
+									ap.Account__c = destinationId;
 								}
 								when 'opportunity' {
-									ap.Opportunity__c = l.ConvertedOpportunityId;
+									destinationId = l.ConvertedOpportunityId;
+									ap.Opportunity__c = destinationId;
 								}
 								when else {
-									ap.Contact__c = l.ConvertedContactId;
+									destinationId = l.ConvertedContactId;
+									ap.Contact__c = destinationId;
 								}
 							}
-							ap.Lead__c = null;
-							toUpdate.add(ap);
+							// The configured destination may not exist for this conversion
+							// (e.g. routed to Opportunity but converted with
+							// DoNotCreateOpportunity). Fall back to the Contact, then the
+							// Account, so the plan always keeps exactly one related record
+							// and the before-update validation doesn't fail the conversion.
+							if (destinationId == null) {
+								if (l.ConvertedContactId != null) {
+									destinationId = l.ConvertedContactId;
+									ap.Contact__c = destinationId;
+								} else if (l.ConvertedAccountId != null) {
+									destinationId = l.ConvertedAccountId;
+									ap.Account__c = destinationId;
+								}
+							}
+							// Only detach from the Lead once a destination is set; otherwise
+							// leave the plan on the Lead rather than orphan it.
+							if (destinationId != null) {
+								ap.Lead__c = null;
+								toUpdate.add(ap);
+							}
 						}
 					}
 				}

--- a/sfdx-source/LabsActionPlans/main/default/classes/ActionPlansTriggerHandlers.cls
+++ b/sfdx-source/LabsActionPlans/main/default/classes/ActionPlansTriggerHandlers.cls
@@ -645,11 +645,16 @@ global inherited sharing class ActionPlansTriggerHandlers {
 			when AFTER_UPDATE {
 				List<ActionPlan__c> leadAPs = [SELECT Id, Lead__c, Contact__c, Account__c, Opportunity__c, Description__c FROM ActionPlan__c WHERE Lead__c IN :newRecordsMap.keySet()];
 
-				Map<Id, ActionPlan__c> apMap = new Map<Id, ActionPlan__c>();
+				// A Lead can have more than one Action Plan; key by Lead to a LIST so
+				// every related plan is reparented on conversion, not just the last one.
+				Map<Id, List<ActionPlan__c>> apMap = new Map<Id, List<ActionPlan__c>>();
 				List<ActionPlan__c> toUpdate = new List<ActionPlan__c>();
 
 				for (ActionPlan__c ap : leadAPs) {
-					apMap.put(ap.Lead__c, ap);
+					if (!apMap.containsKey(ap.Lead__c)) {
+						apMap.put(ap.Lead__c, new List<ActionPlan__c>());
+					}
+					apMap.get(ap.Lead__c).add(ap);
 				}
 
 				String destinationObject = ActionPlansUtilities.getCustomSetting().Default_Object_on_Lead_Conversion__c;
@@ -659,21 +664,21 @@ global inherited sharing class ActionPlansTriggerHandlers {
 
 				for (Lead l : newRecords) {
 					if (l.IsConverted && !oldRecordsMap.get(l.Id).IsConverted && apMap.containsKey(l.Id)) {
-						ActionPlan__c ap = apMap.get(l.Id);
-
-						switch on destinationObject {
-							when 'account' {
-								ap.Account__c = l.ConvertedAccountId;
+						for (ActionPlan__c ap : apMap.get(l.Id)) {
+							switch on destinationObject {
+								when 'account' {
+									ap.Account__c = l.ConvertedAccountId;
+								}
+								when 'opportunity' {
+									ap.Opportunity__c = l.ConvertedOpportunityId;
+								}
+								when else {
+									ap.Contact__c = l.ConvertedContactId;
+								}
 							}
-							when 'opportunity' {
-								ap.Opportunity__c = l.ConvertedOpportunityId;
-							}
-							when else {
-								ap.Contact__c = l.ConvertedContactId;
-							}
+							ap.Lead__c = null;
+							toUpdate.add(ap);
 						}
-						ap.Lead__c = null;
-						toUpdate.add(ap);
 					}
 				}
 				update toUpdate;

--- a/sfdx-source/LabsActionPlans/main/default/classes/tests/ActionPlanCreateInvocableTest.cls
+++ b/sfdx-source/LabsActionPlans/main/default/classes/tests/ActionPlanCreateInvocableTest.cls
@@ -368,6 +368,48 @@ private class ActionPlanCreateInvocableTest {
 	}
 
 	/**
+	 * A dependent task must NOT get a `Task` when the plan is created via the
+	 * invocable — its `Task` is created later (by the APTask trigger) once the
+	 * controlling task is closed. It must also be linked to the controller in
+	 * its OWN plan. Regression test for the invocable creating every task up
+	 * front (releasing successors immediately).
+	 */
+	@IsTest
+	private static void dependentTaskIsNotReleasedImmediately() {
+		ActionPlansTestUtilities testUtil = new ActionPlansTestUtilities();
+
+		Account a = new Account(Name = 'TestAcct');
+		insert a;
+
+		ActionPlanTemplate__c apTemplate = testUtil.createNewActionPlanTemplate(TASK_COUNT);
+
+		// Make the task at TaskIndex 1 depend on the task at TaskIndex 0.
+		List<APTemplateTask__c> templateTasks = [SELECT Id, TaskIndex__c, Dependent__c FROM APTemplateTask__c WHERE Action_Plan_Template__c = :apTemplate.Id ORDER BY TaskIndex__c];
+		for (APTemplateTask__c tt : templateTasks) {
+			tt.Dependent__c = 'None';
+		}
+		templateTasks[1].Dependent__c = String.valueOf(templateTasks[0].TaskIndex__c);
+		update templateTasks;
+
+		Test.startTest();
+		ActionPlanCreateInvocable.CreateActionPlanRequest req = setupRequest(apTemplate.Id, a.Id, 0);
+		List<ActionPlanCreateInvocable.CreateActionPlanRequest> requests = new List<ActionPlanCreateInvocable.CreateActionPlanRequest>();
+		requests.add(req);
+		List<Id> resultIDs = ActionPlanCreateInvocable.makeActionPlanFromTemplate(requests);
+		Test.stopTest();
+
+		Assert.areEqual(1, resultIDs.size(), 'Should have created one Action Plan');
+		// Every template task still yields an APTask...
+		Assert.areEqual(TASK_COUNT, [SELECT COUNT() FROM APTask__c], 'Every template task should yield an APTask');
+		// ...but the one dependent task must not have a Salesforce Task yet.
+		Assert.areEqual(TASK_COUNT - 1, [SELECT COUNT() FROM Task], 'The dependent task must not be created until its controller closes');
+
+		APTask__c dependent = [SELECT Id, Action_Plan__c, Controller__c, Controller__r.Action_Plan__c FROM APTask__c WHERE Dependent__c != 'None' LIMIT 1];
+		Assert.areNotEqual(null, dependent.Controller__c, 'The dependent task should be linked to its controller');
+		Assert.areEqual(dependent.Action_Plan__c, dependent.Controller__r.Action_Plan__c, 'The controller must belong to the same Action Plan');
+	}
+
+	/**
 	 * Helper method for setting up a request for Invocable Apex
 	 *
 	 * @param templateId            Name or Id of Action Plan Template

--- a/sfdx-source/LabsActionPlans/main/default/classes/tests/ActionPlansObjectTriggersTest.cls
+++ b/sfdx-source/LabsActionPlans/main/default/classes/tests/ActionPlansObjectTriggersTest.cls
@@ -326,6 +326,54 @@ private class ActionPlansObjectTriggersTest {
 		Assert.areEqual(1, [SELECT COUNT() FROM ActionPlan__c WHERE Contact__c != NULL], 'Incorrect number of Action Plans created');
 	}
 
+	/**
+	 * A Lead can have more than one Action Plan. On conversion EVERY related
+	 * plan must be reparented to the destination object, not just the last one
+	 * found. Regression test for keying the plan map by Lead Id (which kept
+	 * only one plan per Lead).
+	 */
+	@IsTest
+	private static void leadConversionReparentsAllPlans() {
+		ActionPlansTestUtilities testutil = new ActionPlansTestUtilities();
+		User u = testutil.createTestUser();
+		testutil.assignAPPermissionSets(u.Id, true);
+
+		Lead l;
+		System.runAs(new User(Id = UserInfo.getUserId())) {
+			l = testutil.createNewLead();
+			insert new List<ActionPlan__c>{
+				new ActionPlan__c(Name = 'AP One', StartDate__c = Date.today(), Lead__c = l.Id),
+				new ActionPlan__c(Name = 'AP Two', StartDate__c = Date.today(), Lead__c = l.Id)
+			};
+		}
+
+		Test.startTest();
+		System.runAs(u) {
+			Action_Plans_Settings__c settings = Action_Plans_Settings__c.getInstance();
+			settings.Default_Object_on_Lead_Conversion__c = 'Contact';
+			try {
+				upsert settings;
+			} catch (Exception e) {
+				update settings;
+			}
+			Assert.areEqual(2, [SELECT COUNT() FROM ActionPlan__c WHERE Lead__c = :l.Id], 'Both plans should start on the Lead');
+
+			Database.LeadConvert lc = new Database.LeadConvert();
+			lc.setDoNotCreateOpportunity(true);
+			lc.setLeadId(l.Id);
+
+			LeadStatus convertStatus = [SELECT Id, MasterLabel FROM LeadStatus WHERE IsConverted = TRUE LIMIT 1];
+			lc.setConvertedStatus(convertStatus.MasterLabel);
+
+			Database.LeadConvertResult lcr = Database.convertLead(lc);
+			Assert.isTrue(lcr.isSuccess(), 'Lead conversion failed');
+		}
+		Test.stopTest();
+
+		Assert.areEqual(0, [SELECT COUNT() FROM ActionPlan__c WHERE Lead__c != NULL], 'No plan should remain on the converted Lead');
+		Assert.areEqual(2, [SELECT COUNT() FROM ActionPlan__c WHERE Contact__c != NULL], 'Both plans should be reparented to the Contact');
+	}
+
 	@IsTest
 	private static void leadConversionAccount() {
 		ActionPlansTestUtilities testutil = new ActionPlansTestUtilities();

--- a/sfdx-source/LabsActionPlans/main/default/classes/tests/ActionPlansObjectTriggersTest.cls
+++ b/sfdx-source/LabsActionPlans/main/default/classes/tests/ActionPlansObjectTriggersTest.cls
@@ -374,6 +374,51 @@ private class ActionPlansObjectTriggersTest {
 		Assert.areEqual(2, [SELECT COUNT() FROM ActionPlan__c WHERE Contact__c != NULL], 'Both plans should be reparented to the Contact');
 	}
 
+	/**
+	 * When lead conversion is routed to Opportunity but the Lead is converted
+	 * without creating one (DoNotCreateOpportunity), the plan must fall back to
+	 * the Contact rather than be left with no related record (which would fail
+	 * the ActionPlan before-update validation and break the conversion).
+	 */
+	@IsTest
+	private static void leadConversionFallsBackWhenNoOpportunity() {
+		ActionPlansTestUtilities testutil = new ActionPlansTestUtilities();
+		User u = testutil.createTestUser();
+		testutil.assignAPPermissionSets(u.Id, true);
+
+		Lead l;
+		System.runAs(new User(Id = UserInfo.getUserId())) {
+			l = testutil.createNewLead();
+			insert new ActionPlan__c(Name = 'AP Opp Route', StartDate__c = Date.today(), Lead__c = l.Id);
+		}
+
+		Test.startTest();
+		System.runAs(u) {
+			Action_Plans_Settings__c settings = Action_Plans_Settings__c.getInstance();
+			settings.Default_Object_on_Lead_Conversion__c = 'Opportunity';
+			try {
+				upsert settings;
+			} catch (Exception e) {
+				update settings;
+			}
+
+			Database.LeadConvert lc = new Database.LeadConvert();
+			lc.setDoNotCreateOpportunity(true); // no Opportunity is created
+			lc.setLeadId(l.Id);
+
+			LeadStatus convertStatus = [SELECT Id, MasterLabel FROM LeadStatus WHERE IsConverted = TRUE LIMIT 1];
+			lc.setConvertedStatus(convertStatus.MasterLabel);
+
+			Database.LeadConvertResult lcr = Database.convertLead(lc);
+			Assert.isTrue(lcr.isSuccess(), 'Conversion should succeed even when routed to a non-existent Opportunity');
+		}
+		Test.stopTest();
+
+		Assert.areEqual(0, [SELECT COUNT() FROM ActionPlan__c WHERE Lead__c != NULL], 'Plan should be detached from the converted Lead');
+		Assert.areEqual(0, [SELECT COUNT() FROM ActionPlan__c WHERE Opportunity__c != NULL], 'No Opportunity was created, so the plan should not be on one');
+		Assert.areEqual(1, [SELECT COUNT() FROM ActionPlan__c WHERE Contact__c != NULL], 'Plan should fall back to the Contact');
+	}
+
 	@IsTest
 	private static void leadConversionAccount() {
 		ActionPlansTestUtilities testutil = new ActionPlansTestUtilities();


### PR DESCRIPTION
## Fix six task/dependency bugs in plan creation and lead conversion

This PR fixes six defects in Action Plan creation and lead-conversion handling. Each is a minimal change that mirrors the already-correct sibling path where one exists, plus deterministic regression tests.

### Bugs fixed

1. **`ActionPlansBuilderUtilities` — assignment emails never send.** The "no email" DML options object is never configured: `dmlEmail.EmailHeader.TriggerUserEmail = false` overwrites the *email* options instead of setting `dmlNoEmail`. Tasks created with `SendEmail__c == true` therefore go out with `TriggerUserEmail = false`. Fixed to set `dmlNoEmail`.

2. **`ActionPlanCreateInvocable` — same copy-paste typo** on the invocable creation path.

3. **`ActionPlanCreateInvocable` — wrong record-type status.** Task status is taken from the running user's **default** Task record type rather than the template's record type (`ap.TaskRecordTypeID__c`). In orgs where the default status isn't valid for the template's record type, the `Task` insert can fail or start with the wrong status. Now mirrors the branch already used in `ActionPlansBuilderUtilities`.

4. **`ActionPlanCreateInvocable` — dependent tasks released immediately.** The creation loop builds a `Task` for **every** APTask, including dependents. Dependent tasks should only get a `Task` once their controller is closed (which `ActionPlansTaskTriggerUtilities` already handles, and which the builder path already respects). Now skips `Dependent__c != 'None'` when creating Tasks up front.

5. **`ActionPlansBuilderUtilities` — cross-plan dependency linking.** When creating several plans at once, `aptList` holds the cloned tasks for *all* plans, so indexing it by a template-relative `Dependent__c` makes the second and later plans point their dependents at the **first** plan's controlling task. Now resolves the index against a per-plan task list.

6. **`ActionPlansTriggerHandlers` — only one plan reparented on lead conversion.** The Lead→plan map is keyed by Lead Id with a single value, so a converted Lead with more than one Action Plan keeps only the last; the others stay attached to the converted Lead. Now keys to a `List<ActionPlan__c>` and reparents all.

### Tests

- `ActionPlanCreateInvocableTest.dependentTaskIsNotReleasedImmediately` — a template with a dependent task yields all APTasks but one fewer `Task`, and the dependent links to a controller in its own plan (#4).
- `ActionPlansObjectTriggersTest.leadConversionReparentsAllPlans` — a Lead with two plans reparents **both** on conversion (#6).

Bugs 1–2 are DML email-header flags (not unit-observable); bug 3's record-type branch is gated on Task record types being enabled. Bug 5's multi-plan path runs only through `ActionPlansQueueableBuilder` (whose APTask insert is entangled with the APTask trigger), so it's covered by the existing builder tests plus this review rather than a new per-plan assertion — happy to add one if you'd prefer.

### Additional fixes (dependent-task release + lead conversion)

7. **`ActionPlansTaskTriggerUtilities` — released dependent tasks use the wrong record-type status.** When a closed predecessor releases a dependent task, the new `Task` status was taken from the running user's default record type even though `RecordTypeId` is set from `Task_RecordTypeId__c`. Now uses the dependent task's record type's default status (falling back to the user default when unset).

8. **`ActionPlansTaskTriggerUtilities` — skip-weekend dropped on release.** The released task's due date was recomputed with a raw `addDays`, discarding the plan's skip-weekend adjustment. Now honors `SkipWeekends__c`/`SkipDay__c`, matching how the date is first computed.

9. **`ActionPlansTriggerHandlers` — lead conversion fails when the routed destination doesn't exist.** If conversion is routed to Opportunity but the Lead is converted with `DoNotCreateOpportunity`, `ConvertedOpportunityId` is null and clearing `Lead__c` left the plan with no related record, failing the before-update validation and breaking the whole conversion. Now falls back to Contact/Account and only detaches from the Lead once a destination is set. Test: `ActionPlansObjectTriggersTest.leadConversionFallsBackWhenNoOpportunity`.

---

🤖 This change was generated with [Claude Code](https://claude.com/claude-code) using the Claude Opus 4.8 model.

